### PR TITLE
as per conventional dwebb commit log: fix stuff

### DIFF
--- a/brotop.go
+++ b/brotop.go
@@ -24,7 +24,8 @@ var (
 	Debug          = kingpin.Flag("debug", "Enable debug mode.").Bool()
 	Flush          = kingpin.Flag("flush", "Remove the BroTop cache. (~/.brotop/brotop.db)").Bool()
 	DefaultLogPath = kingpin.Flag("path", "Bro log path.").ExistingDir()
-	ServerPort     = kingpin.Flag("port", "Web server port.").Short('p').String()
+	ServerAddr     = kingpin.Flag("listen", "Web server listener address").Short('l').Default("127.0.0.1").String()
+	ServerPort     = kingpin.Flag("port", "Web server port.").Short('p').Default("8080").String()
 	Quiet          = kingpin.Flag("quiet", "Remove all output logging.").Short('q').Bool()
 
 	OutputChan = make(chan Message)

--- a/server.go
+++ b/server.go
@@ -87,15 +87,11 @@ func StartServer() {
 		w.Write(js)
 	})
 
-	var port string = ":8080"
+	var listen string = fmt.Sprintf("%s:%s", *ServerAddr, *ServerPort)
+	
+	log.Infof("Server listening - http://%s", listen)
 
-	if len(*ServerPort) > 0 {
-		port = fmt.Sprintf(":%s", ServerPort)
-	}
-
-	log.Infof("Server listening - http://%s%s", "127.0.0.1", port)
-
-	err := http.ListenAndServe(port, nil)
+	err := http.ListenAndServe(listen, nil)
 
 	if err != nil {
 		log.Error(err.Error())


### PR DESCRIPTION
This fixes: "-p" not working.

Did this by using kingpin defaults instead of checking for length of arg.
While I was in there, I also added a "-l" option to provider a listener address. 